### PR TITLE
Simplify the compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg
 test/supervise/run-scratch.ts
 test/reload/run-scratch.ts
 .direnv
+bench-results

--- a/spec/SwcCompiler.test.ts
+++ b/spec/SwcCompiler.test.ts
@@ -1,31 +1,38 @@
-import {MissingDestinationError, SwcCompiler} from '../src/SwcCompiler'
+import {CompilationError, SwcCompiler} from '../src/SwcCompiler'
 import * as fs from "fs/promises";
 import os from "os";
 import path from "path";
+import { test, expect } from "@jest/globals";
+import {PathsMap} from "../src/Compiler";
 
-const compile = async (filename: string, root = "fixtures/src") => {
+const compiledContents = async (filename: string, root = "fixtures/src") => {
+  const rootDir = path.join(__dirname, root);
+  const filePath = path.join(rootDir, filename);
+  const paths = await compile(filename, root);
+  return await fs.readFile(paths[filePath], "utf-8");
+}
+
+const compile = async (filename: string, root = "fixtures/src"): Promise<PathsMap> => {
   const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "esbuild-dev-test"));
   const rootDir = path.join(__dirname, root);
-  const fullPath = path.join(rootDir, filename);
+  const filePath = path.join(rootDir, filename);
 
   const compiler = new SwcCompiler(rootDir, workDir)
-  await compiler.compile(fullPath);
-  const compiledFilePath = (await compiler.fileGroup(fullPath))[fullPath]!;
-
-  return await fs.readFile(compiledFilePath, "utf-8");
+  const res =  await compiler.compile(filePath);
+  return res
 }
 
 test("compiles simple files", async () => {
-  const content = await compile("./simple.ts");
+  const content = await compiledContents("./simple.ts");
   expect(content).toContain('console.log("success")')
 });
 
 test("throws if the compilation fails", async () => {
-  await expect(compile("./failing/failing.ts", "fixtures/failing")).rejects.toThrow(MissingDestinationError);
+  await expect(compile("./failing.ts", "fixtures/failing")).rejects.toThrow(CompilationError);
 })
 
 test("compiles lazy import", async () => {
-  const content = await compile("./lazy_import.ts");
+  const content = await compiledContents("./lazy_import.ts");
   expect(content).toContain(`
 function _childProcess() {
     const data = require("child_process");
@@ -38,20 +45,94 @@ function _childProcess() {
 });
 
 test("uses the swc config file from esbuild-dev.js", async () => {
-  const contentWithConfigOverride = await compile("./files_with_config/simple.ts");
+  const contentWithConfigOverride = await compiledContents("./files_with_config/simple.ts");
   expect(contentWithConfigOverride).not.toContain("strict");
 
-  const contentWithoutConfigOverride = await compile("./simple.ts");
+  const contentWithoutConfigOverride = await compiledContents("./simple.ts");
   expect(contentWithoutConfigOverride).toContain("strict");
 });
 
 test("uses the .swcrc file if esbuild-dev.js uses 'swc': '.swcrc'", async () => {
-  const contentWithRootSwcrc = await compile("./files_with_swcrc/simple.ts");
+  const contentWithRootSwcrc = await compiledContents("./files_with_swcrc/simple.ts");
   expect(contentWithRootSwcrc).not.toContain("strict");
 
-  const contentWithNestedSwcrc = await compile("./files_with_swcrc/nested/simple.ts");
+  const contentWithNestedSwcrc = await compiledContents("./files_with_swcrc/nested/simple.ts");
   expect(contentWithNestedSwcrc).toContain("strict");
 
-  const contentWithoutConfigOverride = await compile("./files_with_swcrc/nested/more_nested/simple.ts");
+  const contentWithoutConfigOverride = await compiledContents("./files_with_swcrc/nested/more_nested/simple.ts");
   expect(contentWithoutConfigOverride).toContain("strict");
 });
+
+test("compile returns the file immediately if the group is not available", async () => {
+  const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "esbuild-dev-test"));
+  const rootDir = path.join(__dirname, "fixtures/src");
+  const compiler = new SwcCompiler(rootDir, workDir)
+
+  const compile = async (filename: string) => {
+    const filePath = path.join(rootDir, filename);
+    return await compiler.compile(filePath);
+  }
+
+  const firstTime = await compile("./simple.ts");
+  expect(Object.keys(firstTime)).toHaveLength(1);
+  const secondTime = await compile("./simple.ts");
+  expect(Object.keys(secondTime)).not.toHaveLength(1);
+})
+
+test("compilation targets are cached until invalidated", async () => {
+  const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "esbuild-dev-test"));
+  const rootDir = path.join(__dirname, "fixtures/src");
+  const compiler = new SwcCompiler(rootDir, workDir)
+
+  const newFilePath = path.join(rootDir, "new_simple.ts");
+
+  const compile = async (filename: string) => await fs.readFile((await compiler.compile(filename))[filename], "utf-8");
+
+  try {
+    // Prime the cache
+    await fs.writeFile(newFilePath, "console.log('1')");
+    const content = await compile(newFilePath);
+    expect(content).toContain("'1'");
+
+    // Change the file without invalidation
+    await fs.writeFile(newFilePath, "console.log('2')");
+    const recompiled = await compile(newFilePath);
+    expect(recompiled).toContain("'1'");
+    expect(recompiled).not.toContain("'2'");
+
+    // Invalidate and recompile
+    compiler.invalidate(newFilePath);
+    const afterInvalidation = await compile(newFilePath);
+    expect(afterInvalidation).toContain("'2'");
+    expect(afterInvalidation).not.toContain("'1'");
+  } finally {
+    await fs.rm(newFilePath);
+  }
+})
+
+test("invalidateBuildSet invalidates all files", async () => {
+  const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "esbuild-dev-test"));
+  const rootDir = path.join(__dirname, "fixtures/src");
+  const compiler = new SwcCompiler(rootDir, workDir)
+
+  const newFilePath = path.join(rootDir, "new_simple.ts");
+
+  const compile = async (filename: string) => await fs.readFile((await compiler.compile(filename))[filename], "utf-8");
+
+  try {
+    // Prime the cache
+    await fs.writeFile(newFilePath, "console.log('1')");
+    const content = await compile(newFilePath);
+    expect(content).toContain("'1'");
+
+    await fs.writeFile(newFilePath, "console.log('2')");
+
+    // Invalidate and recompile
+    await compiler.invalidateBuildSet();
+    const afterInvalidation = await compile(newFilePath);
+    expect(afterInvalidation).toContain("'2'");
+    expect(afterInvalidation).not.toContain("'1'");
+  } finally {
+    await fs.rm(newFilePath);
+  }
+})

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -1,3 +1,5 @@
+export type PathsMap = Record<string, string>;
+
 export type Compiler = {
   /**
    * When a file operation occurs that requires setting up all the esbuild builds again, we run this.
@@ -11,22 +13,12 @@ export type Compiler = {
   invalidateBuildSet(): Promise<void>;
 
   /**
-   * Compiles a new file at `filename`.
-   **/
-  compile(filename: string): Promise<void>;
-
-  /**
-   * For a given input filename, return all the destinations of the files compiled alongside it in its compilation group.
-   **/
-  fileGroup(filename: string): Promise<Record<string, string>>;
-
-  /**
    * Invalidates a compiled file, after it changes on disk.
    */
   invalidate(filename: string): void;
 
   /**
-   * Rebuilds invalidated files
-   */
-  rebuild(): Promise<void>;
+   * Compiles a new file at `filename`. Returns a Promise<PathsMap> containing the files compiled as part of this compilation unit.
+   **/
+  compile(filename: string): Promise<PathsMap>;
 };

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -49,7 +49,6 @@ export class Project {
     if (invalidate) {
       await this.compiler.invalidateBuildSet();
     }
-    await this.compiler.rebuild();
     this.supervisor.restart();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,9 +100,9 @@ const startFilesystemWatcher = (project: Project) => {
 const startIPCServer = async (socketPath: string, project: Project) => {
   const compile = async (filename: string) => {
     try {
-      await project.compiler.compile(filename);
+      const pathsMap = await project.compiler.compile(filename);
       project.watcher?.add(filename);
-      return await project.compiler.fileGroup(filename);
+      return pathsMap;
     } catch (error) {
       log.error(`Error compiling file ${filename}:`, error);
     }


### PR DESCRIPTION
Now that we don't support `esbuild` anymore, we can simplify the `Compiler` interface and remove the peculiarities introduced by supporting 2 backends.

This leaves with 3 methods:
- `compile(filename): PathsMap`
- `invalidate(filename): void`
- `invalidateBuildSet(): void`

Additionally, I changed the `SwcCompiler` some more. The `CompilationTarget.destination` field was changed to a `Promise<path>`, allowing us to return immediately and `await` the destination when they become necessary. This leads to very modest changes (sometimes within the margin for error) when many files in the compilation group ended up being required. Gains were not insignificant when compiling many files but loading few, but I don't think this is a common usage pattern (just my gut feeling).

I chose to introduce it anyhow, even though this leads to more complexity in handling the promises because the alternative is handling invalidated files; we need to keep their `config` around in order to avoid performing `getModule` multiple times (it's very expensive). 

Versions between this one and (inclusively) `gm/swc-config` have a regression where invalidating a file is very costly at reload time.
