### PR TITLE
fix(swc): reset invalidatedFiles when invalidating the entire build set

### DIFF
--- a/src/SwcCompiler.ts
+++ b/src/SwcCompiler.ts
@@ -88,6 +88,7 @@ export class SwcCompiler implements Compiler {
   }
 
   async invalidateBuildSet() {
+    this.invalidatedFiles = new Set();
     this.compiledFiles = new CompiledFiles();
   }
 
@@ -163,6 +164,7 @@ export class SwcCompiler implements Compiler {
     const file = { filename, root, destination, config };
 
     this.compiledFiles.addFile(file);
+    this.invalidatedFiles.delete(filename);
 
     return file;
   }


### PR DESCRIPTION
This fixes a pretty significant perf regression when invalidating the build set while simultaneously invalidating lots of files. This would typically happen when changing git branches. 

The problem was that the `invalidatedFiles` was never pruned. Thus, when changing branches, this would happen:

- Many files would be changed by `git` and then `invalidate()`, leading to a large list
- Once a 15 ms (debounce delay) pause was obtained, `rebuild` would be called
- This would recompile the entire set of `invalidatedFiles` in parallel, each one eventually calling `getModule()`
- `getModule` performs expensive FS operations

What's more, because the list was not maintained, it could contain files that have been removed in the `git` tree. The `SwcCompiler` would then try to compile those files agian, to no avail.

This PR fixes the bug when `invalidateBuildSet` is called by clearing both caches (`invalidatedFiles` and `compiledFiles`). The next file requested will cause the entire group to be compiled.

It does not, however, fully address the issue expressed in #34. The reason is that, if a large list of `invalidatedFiles` is built, calling `rebuild()` will call `getModule()` for each, producing the expensive operation for each.