### PR TITLE
Drop buggy resiliency code to node bug now that node bug has been fixed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "prerelease": "gitpkg publish",
     "test": "jest"
   },
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "@cspotcode/source-map-support": "^0.7.0",
     "@swc/core": "^1.2.152",

--- a/src/SyncWorker.ts
+++ b/src/SyncWorker.ts
@@ -18,7 +18,7 @@ interface SyncWorkerResponse {
 }
 
 export interface SyncWorkerData {
-  isESBuildDevWorker: true;
+  isWDSSyncWorker: true;
   scriptPath: string;
   port: MessagePort;
 }
@@ -41,7 +41,7 @@ export class SyncWorker {
     const workerData: SyncWorkerData = {
       scriptPath,
       port: port2,
-      isESBuildDevWorker: true,
+      isWDSSyncWorker: true,
     };
 
     this.worker = new Worker(__filename, {
@@ -109,10 +109,8 @@ export class SyncWorker {
 // This file re-executes itself in the worker thread. Actually run the worker code within the inner thread if we're the inner thread
 if (!workerThreads.isMainThread) {
   const runWorker = async () => {
-    // try to be immune to https://github.com/nodejs/node/issues/36531
     const workerData: SyncWorkerData | undefined = workerThreads.workerData;
-    if (!workerData) return setImmediate(runWorker as any); // eslint-disable-line @typescript-eslint/no-implied-eval
-    if (!workerData.isESBuildDevWorker) return;
+    if (!workerData || !workerData.isWDSSyncWorker) return;
 
     const file = process.env["WDS_DEBUG"] ? await fs.open("/tmp/wds-debug-log.txt", "w") : undefined;
     const implementation = require(workerData.scriptPath); // eslint-disable-line @typescript-eslint/no-var-requires

--- a/src/child-process-registration.ts
+++ b/src/child-process-registration.ts
@@ -34,7 +34,7 @@ const notifyParentProcessOfRequire = (filename: string) => {
   void throttledRequireFlush();
 };
 
-if (!workerData || !(workerData as SyncWorkerData).isESBuildDevWorker) {
+if (!workerData || !(workerData as SyncWorkerData).isWDSSyncWorker) {
   const worker = new SyncWorker(path.join(__dirname, "child-process-ipc-worker.js"));
   const paths: Record<string, string> = {};
 


### PR DESCRIPTION
When wds first came into existence, node's `worker_threads` module had a bug where sometimes a worker thread's data wouldn't be synchronously available to it. This made the `SyncWorker` code need to be careful -- if the bug had triggered, it needed to wait for a bit until the data was available to start working. This `setImmediate` call worked for this purpose, but, was an infinite loop bug lying in wait!

`SyncWorker` has the unfortunate privilege of always being required by any code running under wds, in the main thread or in any other worker threads. Node passes the same `--require` flags to worker threads, so they get the same registration stuff that wds sets up, which is desirable so that worker threads can also require TypeScript code using wds. This makes `SyncWorker` need to be smart though, and be aware of if it is being required by a "parent" thread, be it a main thread or any not-wds worker thread, or if it is being required by a "child" thread for powering the parent's SyncWorker. The `SyncWorker` code needs the worker data for this, and without it, doesn't know what to do.

If no worker data is passed to some non-wds worker thread, SyncWorker will be required, but not see any worker data, and trigger this `setImmediate` defense mechanism infinitely. Oops. We can't know if the worker data is absent cause of the bug, or if it is absent cause it really wasn't passed and it is just not a `SyncWorker` thread. So instead, we choose to only support node versions without the bug. Kinda unfortunate, but also, not really sure there is another option.
