### PR TITLE
Make swc the default compiler

### DIFF
--- a/spec/SwcCompiler.test.ts
+++ b/spec/SwcCompiler.test.ts
@@ -1,4 +1,4 @@
-import {MissingDestinationError, SwcCompiler} from '../src/SwcCompiler'
+import { MissingDestinationError, SwcCompiler } from '../src/SwcCompiler'
 import * as fs from "fs/promises";
 import os from "os";
 import path from "path";

--- a/src/EsBuildCompiler.ts
+++ b/src/EsBuildCompiler.ts
@@ -124,6 +124,7 @@ export class EsBuildCompiler implements Compiler {
         root,
         promptedBy: filename,
         files: fileNames.length,
+        compiler: "esbuild",
       });
 
       this.builds.push(build);

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -8,7 +8,7 @@ export interface RunOptions {
   terminalCommands: boolean;
   reloadOnChanges: boolean;
   supervise: boolean;
-  useSwc: boolean;
+  useEsbuild: boolean;
 }
 
 export interface ProjectConfig {

--- a/src/SwcCompiler.ts
+++ b/src/SwcCompiler.ts
@@ -185,6 +185,7 @@ export class SwcCompiler implements Compiler {
       root,
       promptedBy: filename,
       files: fileNames.length,
+      compiler: "swc",
     });
   }
 

--- a/src/bench/bench.ts
+++ b/src/bench/bench.ts
@@ -36,7 +36,7 @@ function monitorLogs(childProcess: ChildProcess): Promise<ChildProcessResult> {
   });
 }
 
-function spawnOnce(args: { supervise?: boolean; filename: string; swc: boolean }): ChildProcess {
+function spawnOnce(args: { supervise?: boolean; filename: string; esbuild: boolean }): ChildProcess {
   const extraArgs = [];
 
   if (args.supervise) {
@@ -44,8 +44,8 @@ function spawnOnce(args: { supervise?: boolean; filename: string; swc: boolean }
     extraArgs.push("--watch");
   }
 
-  if (args.swc) {
-    extraArgs.push("--swc");
+  if (args.esbuild) {
+    extraArgs.push("--esbuild");
   }
 
   const binPath = path.resolve("pkg/wds.bin.js");
@@ -111,7 +111,7 @@ function report(results: Array<RunResult>): Record<string, Record<string, number
 }
 
 export type BenchArgs = {
-  swc: boolean;
+  esbuild: boolean;
   runs: number;
   argv: Array<string>;
 };
@@ -134,7 +134,7 @@ export async function benchBoot(args: BenchArgs): Promise<void> {
 
   for (let i = 0; i < args.runs; i++) {
     const startTime = process.hrtime.bigint();
-    const childProcess = spawnOnce({ filename: execPath(args), swc: args.swc });
+    const childProcess = spawnOnce({ filename: execPath(args), esbuild: args.esbuild });
     const result = await monitorLogs(childProcess);
     const endTime = process.hrtime.bigint();
     results.push({
@@ -158,7 +158,7 @@ export async function benchReload(args: BenchArgs): Promise<void> {
 
   process.stdout.write(`Starting reload benchmark (pid=${process.pid})\n`);
 
-  const childProcess = spawnOnce({ supervise: true, filename: filepath, swc: args.swc });
+  const childProcess = spawnOnce({ supervise: true, filename: filepath, esbuild: args.esbuild });
   const _ignoreInitialBoot = await monitorLogs(childProcess);
 
   for (let i = 0; i < args.runs; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,18 +39,18 @@ export const cli = async () => {
       description: "Supervise and restart the process when it exits indefinitely",
       default: false,
     })
-    .option("swc", {
+    .option("esbuild", {
       type: "boolean",
-      description: "Use SWC instead of esbuild",
+      description: "Use esbuild instead of sec",
       default: false,
     }).argv;
 
-  return await esbuildDev({
+  return await wds({
     argv: args._ as any,
     terminalCommands: args.commands,
     reloadOnChanges: args.watch,
     supervise: args.supervise,
-    useSwc: args.swc,
+    useEsbuild: args.esbuild,
   });
 };
 
@@ -135,7 +135,7 @@ const childProcessArgs = () => {
   return ["-r", path.join(__dirname, "child-process-registration.js"), "-r", require.resolve("@cspotcode/source-map-support/register")];
 };
 
-export const esbuildDev = async (options: RunOptions) => {
+export const wds = async (options: RunOptions) => {
   const workspaceRoot = findWorkspaceRoot(process.cwd()) || process.cwd();
   const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "wds"));
   log.debug(`starting wds for workspace root ${workspaceRoot} and workdir ${workDir}`);
@@ -147,7 +147,8 @@ export const esbuildDev = async (options: RunOptions) => {
     serverSocketPath = path.join(workDir, "ipc.sock");
   }
 
-  const compiler = options.useSwc ? new SwcCompiler(workspaceRoot, workDir) : new EsBuildCompiler(workspaceRoot, workDir);
+  const compiler = options.useEsbuild ? new EsBuildCompiler(workspaceRoot, workDir) : new SwcCompiler(workspaceRoot, workDir);
+
   const project = new Project(workspaceRoot, await projectConfig(findRoot(process.cwd())), compiler);
   project.supervisor = new Supervisor([...childProcessArgs(), ...options.argv], serverSocketPath, options, project);
 

--- a/src/wds-bench.bin.js
+++ b/src/wds-bench.bin.js
@@ -10,9 +10,9 @@ export const cli = async () => {
       type: "number",
       default: 10,
     })
-    .option("swc", {
+    .option("esbuild", {
       type: "boolean",
-      description: "Use the SWC compiler",
+      description: "Use the esbuild compiler",
     })
     .option("type", {
       choices: ["boot", "reload"],
@@ -26,7 +26,7 @@ export const cli = async () => {
   const benchArgs = {
     runs: args.runs,
     argv: args._,
-    swc: args.swc,
+    esbuild: args.esbuild,
   };
 
   switch (args.type) {

--- a/test/test.sh
+++ b/test/test.sh
@@ -3,7 +3,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 echo $DIR
 set -e
 
-ALL_ARGS=("--no-swc" "--swc")
+ALL_ARGS=("--no-esbuild" "--esbuild")
 
 for args in "${ALL_ARGS[@]}"; do
   echo "::group::Simple test ${args}"


### PR DESCRIPTION
We've been using swc at Gadget for a few months now and found it to be quite a bit faster and have better coverage for features like lazy imports and dynamic imports. Let's make it the default!