### PR TITLE
Prevent project shutdown on watch mode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ wds --inspect some-test.test.ts
 
 - Builds and runs TypeScript really fast (using [`swc`](https://github.com/swc-project/swc) or [`esbuild`](https://github.com/evanw/esbuild))
 - Incrementally rebuilds only what has changed in the `--watch` mode, and restarts the process when files change
-- Supervises the node.js process with `--supervise` to keep incremental context around on process crash, and can restart on demand in the `--commands` mode
+- Execute commands on demand with the `--commands` mode
 - Plays nice with node.js command line flags like `--inspect` or `--prof`
 - Produces sourcemaps which Just Work™️ by default for debugging with many editors (VSCode, IntelliJ, etc)
 - Monorepo aware, allowing for different configuration per package and only compiling what is actually required from the monorepo context

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -7,7 +7,6 @@ export interface RunOptions {
   argv: string[];
   terminalCommands: boolean;
   reloadOnChanges: boolean;
-  supervise: boolean;
   useEsbuild: boolean;
 }
 

--- a/src/Supervisor.ts
+++ b/src/Supervisor.ts
@@ -46,7 +46,7 @@ export class Supervisor extends EventEmitter {
 
     this.process.on("message", (value) => this.emit("message", value));
     this.process.on("exit", (code, signal) => {
-      if (signal !== "SIGKILL" && this.options.supervise) {
+      if (signal !== "SIGKILL") {
         log.warn(`process exited with ${code}`);
       }
     });

--- a/src/bench/bench.ts
+++ b/src/bench/bench.ts
@@ -36,11 +36,10 @@ function monitorLogs(childProcess: ChildProcess): Promise<ChildProcessResult> {
   });
 }
 
-function spawnOnce(args: { supervise?: boolean; filename: string; esbuild: boolean }): ChildProcess {
+function spawnOnce(args: { watch?: boolean; filename: string; esbuild: boolean }): ChildProcess {
   const extraArgs = [];
 
-  if (args.supervise) {
-    extraArgs.push("--supervise");
+  if (args.watch) {
     extraArgs.push("--watch");
   }
 
@@ -158,7 +157,7 @@ export async function benchReload(args: BenchArgs): Promise<void> {
 
   process.stdout.write(`Starting reload benchmark (pid=${process.pid})\n`);
 
-  const childProcess = spawnOnce({ supervise: true, filename: filepath, esbuild: args.esbuild });
+  const childProcess = spawnOnce({ watch: true, filename: filepath, esbuild: args.esbuild });
   const _ignoreInitialBoot = await monitorLogs(childProcess);
 
   for (let i = 0; i < args.runs; i++) {

--- a/test/reload/test.sh
+++ b/test/reload/test.sh
@@ -9,12 +9,12 @@ trap "kill -9 0" INT TERM
 trap 'kill $(jobs -p)' EXIT
 
 # run a server in the background
-$DIR/../../pkg/wds.bin.js $@ --supervise --commands $DIR/run-scratch.ts &
+$DIR/../../pkg/wds.bin.js $@ --commands $DIR/run-scratch.ts &
 
 max_retry=5
 counter=0
 
-set +e 
+set +e
 until curl -s localhost:8080 | grep "World"
 do
    sleep 1


### PR DESCRIPTION
Hi, I've just discovered this package and I was surprised on how fast it was 🚀 

Unfortunately I tried using it on `watch` mode, but the program kept ending on any file change (apparently someone else has already noticed the same issue #45 )

So... this is my shot into fixing it 🐞 

### Issue

In order to react to changes in our files, the `watcher` triggers a `change` event, that in turn triggers a `project reload`.

This `project reload` forces a `supervisor` restart, that in the code is implemented by killing the current process and creating a new one.

https://github.com/gadget-inc/wds/blob/f89b208082eefb9b0977b6a32abdd65f9ee266fc/src/Supervisor.ts#L32-L46

This `process exit` is caught in the `supervisor exit` event, but it's only prevented for the `supervise mode`  case.

https://github.com/gadget-inc/wds/blob/f89b208082eefb9b0977b6a32abdd65f9ee266fc/src/index.ts#L172-L177

### Possible solution
My proposed solution is to add the missing `reload on changes mode` case, preventing to kill our 'project' on any file change.

### Images

Running original file (watch mode is enabled by default)
![image](https://user-images.githubusercontent.com/26639800/177490814-d5332c96-44fc-481f-b8ae-8e3dea69e52c.png)

Modifying and saving changes to file
![image](https://user-images.githubusercontent.com/26639800/177490925-fe9a6c40-985e-4320-8f83-06f9f80a3ebc.png)

Previously the program would just end, like in the logs of #45
