### PR TITLE
Proxy Node IPC messages

### DIFF
--- a/spec/Supervisor.spec.ts
+++ b/spec/Supervisor.spec.ts
@@ -1,0 +1,49 @@
+import {spawn} from "child_process";
+import * as path from "path";
+import {range} from "lodash";
+
+test("it proxies ipc messages", async () => {
+  const binPath = path.join(__dirname, "../pkg/wds.bin.js");
+  const scriptPath = path.join(__dirname, "fixtures/src/add.ts");
+
+  const child = spawn(
+    "node",
+    [binPath, scriptPath],
+    {
+      stdio: ["inherit", "inherit", "inherit", "ipc"],
+      env: process.env,
+    }
+  );
+
+  const childHasBooted = new Promise<void>((resolve) => {
+    const handler = () => {
+      resolve();
+      child.off("message", handler)
+    };
+    child.on("message", handler)
+  })
+  await childHasBooted;
+
+  const messagesToChild = range(0, 3);
+  const messagesFromChild: Array<number> = [];
+
+  const promise = new Promise<void>((resolve) => {
+    child.on("message", (message: any) => {
+      messagesFromChild.push(message)
+
+      if (messagesFromChild.length === messagesToChild.length) {
+        resolve();
+      }
+    });
+  });
+
+  for (let number of messagesToChild) {
+    child.send(number);
+  }
+
+  child.send("exit");
+
+  await promise;
+
+  expect(messagesFromChild).toEqual([1, 2, 3]);
+})

--- a/spec/Supervisor.spec.ts
+++ b/spec/Supervisor.spec.ts
@@ -47,3 +47,24 @@ test("it proxies ipc messages", async () => {
 
   expect(messagesFromChild).toEqual([1, 2, 3]);
 })
+
+test("it doesn't setup ipc if it wasn't setup with ipc itself", async () => {
+  const binPath = path.join(__dirname, "../pkg/wds.bin.js");
+  const scriptPath = path.join(__dirname, "fixtures/src/no-ipc.ts");
+
+  const child = spawn(
+    "node",
+    [binPath, scriptPath],
+    {
+      stdio: ["inherit", "inherit", "inherit"],
+      env: process.env,
+    }
+  );
+
+  await new Promise<void>((resolve) => {
+    child.on("exit", (code) => {
+      resolve();
+      expect(code).toEqual(0);
+    });
+  });
+});

--- a/spec/fixtures/src/add.ts
+++ b/spec/fixtures/src/add.ts
@@ -1,0 +1,11 @@
+const timeout = setTimeout(() => null, Math.pow(2, 31) - 1);
+process.on("message", (message: any) => {
+  if (message === "exit") {
+    clearTimeout(timeout);
+    process.exit(0);
+  } else {
+    process.send(message + 1);
+  }
+});
+
+process.send("ready");

--- a/spec/fixtures/src/no-ipc.ts
+++ b/spec/fixtures/src/no-ipc.ts
@@ -1,0 +1,4 @@
+if (process.send) {
+  // The process was started with IPC
+  process.exit(1);
+}


### PR DESCRIPTION
In most cases, we expect `wds` to be called directly from the CLI. However, it happends that `wds` would be forked from a `node` process. The parent process may have setup IPC in the child's `stdio`. In those cases, we can have `wds` transparently relay the messages from its own child to the parent process.

This is extremely useful when developing two TypeScript processes that communicate via IPC; both can be loaded independently by `wds` during development.