### PR TITLE
Run tests without watch mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 on:
   push:
   workflow_call:
+  pull_request:
 
 jobs:
   build:

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # wds
 
-A reloading dev server for server side TypeScript projects. Compiles TypeScript _real_ fast, on demand, using `require.extensions`, and restarts the server when things change. Similar to and inspired by `ts-node-dev`.
+A reloading dev server for server side TypeScript projects. Compiles TypeScript _real_ fast, on demand, using `require.extensions`. Similar to and inspired by `ts-node-dev`.
 
 wds stands for Whirlwind (or web) Development Server.
 
@@ -9,10 +9,10 @@ wds stands for Whirlwind (or web) Development Server.
 After installing `wds`, you can use it like you might use the `node` command line program:
 
 ```shell
-# run one script with wds compiling TS to JS as it is required
+# run one script with wds compiling TS to JS
 wds some-script.ts
 
-# run one server with wds watching the files for changes, and re-running the server when they change
+# run one server with wds `watch` mode, re-running the server on any file changes
 wds --watch some-server.ts
 
 # run one script with node command line arguments that you'd normally pass to `node`
@@ -22,7 +22,7 @@ wds --inspect some-test.test.ts
 ## Features
 
 - Builds and runs TypeScript really fast (using [`swc`](https://github.com/swc-project/swc) or [`esbuild`](https://github.com/evanw/esbuild))
-- Incrementally rebuilds only what has changed in the `--watch` mode, and restarts the process when files change
+- Incrementally rebuilds only what has changed in `--watch` mode, restarting the process on file changes
 - Execute commands on demand with the `--commands` mode
 - Plays nice with node.js command line flags like `--inspect` or `--prof`
 - Supports node.js `ipc` channels between the process starting `wds` and the node.js process started by `wds`.
@@ -45,7 +45,7 @@ Options:
                    stdin from being forwarded to the process. Only command right
                    now is `rs` to restart the server. [boolean] [default: false]
   -w, --watch      Trigger restarts by watching for changes to required files
-                                                       [boolean] [default: true]
+                                                      [boolean] [default: false]
   -s, --supervise  Supervise and restart the process when it exits indefinitely
                                                       [boolean] [default: false]
       --esbuild    Use esbuild for compiling files    [boolean] [default: false]

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export const cli = async () => {
       alias: "w",
       type: "boolean",
       description: "Trigger restarts by watching for changes to required files",
-      default: true,
+      default: false,
     })
     .option("esbuild", {
       type: "boolean",

--- a/test/reload/test.sh
+++ b/test/reload/test.sh
@@ -9,7 +9,7 @@ trap "kill -9 0" INT TERM
 trap 'kill $(jobs -p)' EXIT
 
 # run a server in the background
-$DIR/../../pkg/wds.bin.js $@ --commands $DIR/run-scratch.ts &
+$DIR/../../pkg/wds.bin.js $@ --watch --commands $DIR/run-scratch.ts &
 
 max_retry=5
 counter=0


### PR DESCRIPTION
### Description

Now that watch mode keeps waiting for new changes, it no longer exists on completion, making tests to run indefinitely. So... this is this is definitely my bad from #47

This is fixed by passing the option `--no-watch`, but probably a better solution would be to have an option like described in https://github.com/gadget-inc/wds/pull/47#issuecomment-1177620466

I've also modified the Github workflow test, to run it on pull requests and have a timeout of 30 minutes.
