### PR TITLE
Allow WDS to proxy stdin if not started with '--commands'

### DIFF
--- a/spec/fixtures/src/echo.ts
+++ b/spec/fixtures/src/echo.ts
@@ -1,0 +1,13 @@
+process.stdin.resume();
+
+async function main() {
+  if (!process.stdin.readable) {
+    process.stdout.write("stdin is not readable");
+  }
+  process.stdin.pipe(process.stdout);
+  process.stdin.on("end", () => {
+    process.exit(0);
+  })
+}
+
+main()

--- a/src/Supervisor.ts
+++ b/src/Supervisor.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, spawn } from "child_process";
+import { ChildProcess, spawn, StdioOptions } from "child_process";
 import { EventEmitter } from "events";
 import { RunOptions } from "./Options";
 import { Project } from "./Project";
@@ -34,7 +34,10 @@ export class Supervisor extends EventEmitter {
       this.process.kill("SIGKILL");
     }
 
-    const stdio: Array<null | "inherit" | "ipc"> = [null, "inherit", "inherit"];
+    const stdio: StdioOptions = [null, "inherit", "inherit"];
+    if (!this.options.terminalCommands) {
+      stdio[0] = "inherit";
+    }
     if (process.send) {
       // WDS was called from a process that has IPC
       stdio.push("ipc");
@@ -48,6 +51,10 @@ export class Supervisor extends EventEmitter {
       },
       stdio: stdio,
     });
+
+    if (this.options.terminalCommands) {
+      this.process.stdin!.end();
+    }
 
     const onChildProcessMessage = (message: any) => {
       if (process.send) process.send(message);


### PR DESCRIPTION
As discussed previously, when `wds` is started without `--commands`, the stdin should be available to the child process. 