### PR TITLE
Added request error handling to notification flush

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wds",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "author": "Harry Brundage",
   "license": "MIT",
   "bin": {

--- a/src/child-process-registration.ts
+++ b/src/child-process-registration.ts
@@ -20,6 +20,9 @@ const throttledRequireFlush = throttle(() => {
       300
     );
 
+    request.on("error", (error: any) => {
+      log.debug(`Unexpected request error while flushing require notifications`, error);
+    });
     request.write(JSON.stringify(pendingRequireNotifications));
     request.end();
     pendingRequireNotifications = [];


### PR DESCRIPTION
During our Internal GREAT FLAKE SHAKE we discovered that sometimes the wds child process will attempt to forward notifications to the parent when the parent is not active. This lead to sparse `EPIPE` errors being thrown.

The underlying issue of the child forwarding requests to the parent exists, but this at least will avoid any crashing due to uncaught exceptions.