### PR TITLE
Suppress EPERM when killing child processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wds",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "author": "Harry Brundage",
   "license": "MIT",
   "bin": {

--- a/src/Supervisor.ts
+++ b/src/Supervisor.ts
@@ -36,9 +36,8 @@ export class Supervisor extends EventEmitter {
       try {
         process.kill(-pid, signal);
       } catch (error: any) {
-        if (error.code == "ESRCH") {
-          // process can't be found, is already dead
-          return;
+        if (error.code == "ESRCH" || error.code == "EPERM") {
+          // process can't be found or can't be killed again, its already dead
         } else {
           throw error;
         }


### PR DESCRIPTION
This is the signal OS X throws when trying to kill a process group where
the pid has already stopped
