### PR TITLE
Write files to disk atomically so they are never empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "globby": "^11.1.0",
     "lodash": "^4.17.20",
     "pkg-dir": "^5.0.0",
+    "write-file-atomic": "^6.0.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {
@@ -55,6 +56,7 @@
     "@types/jest": "^27.4.0",
     "@types/lodash": "^4.14.194",
     "@types/node": "^18.11.9",
+    "@types/write-file-atomic": "^4.0.3",
     "@types/yargs": "^15.0.14",
     "eslint": "^8.40.0",
     "eslint-plugin-jest": "^27.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   pkg-dir:
     specifier: ^5.0.0
     version: 5.0.0
+  write-file-atomic:
+    specifier: ^6.0.0
+    version: 6.0.0
   yargs:
     specifier: ^16.2.0
     version: 16.2.0
@@ -55,6 +58,9 @@ devDependencies:
   '@types/node':
     specifier: ^18.11.9
     version: 18.11.9
+  '@types/write-file-atomic':
+    specifier: ^4.0.3
+    version: 4.0.3
   '@types/yargs':
     specifier: ^15.0.14
     version: 15.0.14
@@ -612,7 +618,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
       jest-mock: 27.5.1
     dev: true
 
@@ -622,7 +628,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -1008,13 +1014,13 @@ packages:
     resolution: {integrity: sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==}
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
     dev: true
 
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
     dev: true
 
   /@types/istanbul-lib-coverage@2.0.4:
@@ -1094,6 +1100,12 @@ packages:
 
   /@types/which@3.0.3:
     resolution: {integrity: sha512-2C1+XoY0huExTbs8MQv1DuS5FS86+SEjdM9F/+GS61gg5Hqbtj8ZiDSx8MfWcyei907fIPbfPGCOrNUTnVHY1g==}
+    dev: true
+
+  /@types/write-file-atomic@4.0.3:
+    resolution: {integrity: sha512-qdo+vZRchyJIHNeuI1nrpsLw+hnkgqP/8mlaN6Wle/NKhydHmUN9l4p3ZE8yP90AJNJW4uB8HQhedb4f1vNayQ==}
+    dependencies:
+      '@types/node': 18.19.15
     dev: true
 
   /@types/yargs-parser@20.2.0:
@@ -2900,7 +2912,6 @@ packages:
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
-    dev: true
 
   /indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -3149,7 +3160,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
       chalk: 4.1.0
       co: 4.6.0
       dedent: 0.7.0
@@ -3274,7 +3285,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -3292,7 +3303,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -3330,7 +3341,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
       chalk: 4.1.0
       co: 4.6.0
       expect: 27.5.1
@@ -3385,7 +3396,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
     dev: true
 
   /jest-pnp-resolver@1.2.3(jest-resolve@27.5.1):
@@ -3498,7 +3509,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
       graceful-fs: 4.2.9
     dev: true
 
@@ -3573,7 +3584,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.11.9
+      '@types/node': 18.19.15
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -4431,6 +4442,11 @@ packages:
     resolution: {integrity: sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==}
     dev: true
 
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: false
+
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
@@ -4975,6 +4991,14 @@ packages:
       signal-exit: 3.0.6
       typedarray-to-buffer: 3.1.5
     dev: true
+
+  /write-file-atomic@6.0.0:
+    resolution: {integrity: sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
+    dev: false
 
   /ws@7.5.9:
     resolution: {integrity: sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==}

--- a/src/SwcCompiler.ts
+++ b/src/SwcCompiler.ts
@@ -1,4 +1,5 @@
 import type { Config, Options } from "@swc/core";
+import writeFileAtomic from "write-file-atomic";
 import { transformFile } from "@swc/core";
 import findRoot from "find-root";
 import * as fs from "fs/promises";
@@ -163,7 +164,7 @@ export class SwcCompiler implements Compiler {
 
     const destination = path.join(this.outDir, filename).replace(this.workspaceRoot, "");
     await fs.mkdir(path.dirname(destination), { recursive: true });
-    await fs.writeFile(destination, output.code);
+    await writeFileAtomic(destination, output.code);
     const file = { filename, root, destination, config };
 
     this.compiledFiles.addFile(file);

--- a/src/SyncWorker.ts
+++ b/src/SyncWorker.ts
@@ -1,7 +1,7 @@
 // have to use a module import like this so we can re-access imported properties as they might change, see https://github.com/nodejs/node/issues/36531
 import { promises as fs } from "fs";
 import type { MessagePort } from "worker_threads";
-import workerThreads, { MessageChannel, receiveMessageOnPort, Worker } from "worker_threads";
+import workerThreads, { MessageChannel, receiveMessageOnPort, threadId, Worker } from "worker_threads";
 import { log } from "./utils";
 
 log.debug("syncworker file boot", { isMainThread: workerThreads.isMainThread, hasWorkerData: !!workerThreads.workerData });
@@ -52,7 +52,7 @@ export class SyncWorker {
       transferList: [port2],
     });
 
-    log.debug("booted syncworker worker", { filename: __filename, scriptPath, threadId: this.worker.threadId });
+    log.debug("booted syncworker worker", { filename: __filename, scriptPath, childWorkerThreadId: this.worker.threadId });
 
     this.worker.on("error", (error) => {
       log.error("[wds] Internal error", error);
@@ -82,7 +82,7 @@ export class SyncWorker {
 
     const sharedBufferView = new Int32Array(call.sharedBuffer);
 
-    log.debug("calling syncworker", call);
+    log.debug("calling syncworker", { thisThreadId: threadId, childWorkerThreadId: this.worker.threadId, call });
     this.port.postMessage(call);
 
     // synchronously wait for worker thread to get back to us

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,9 @@ import { promises as fs } from "fs";
 import { defaults } from "lodash";
 import path from "path";
 import type { ProjectConfig } from "./Options";
+import { threadId } from "worker_threads";
 
-const logPrefix = `[wds pid=${process.pid}]`;
+const logPrefix = `[wds pid=${process.pid} thread=${threadId}]`;
 export const log = {
   debug: (...args: any[]) => process.env["WDS_DEBUG"] && console.warn(logPrefix, ...args),
   info: (...args: any[]) => console.warn(logPrefix, ...args),


### PR DESCRIPTION
This fixes a bug where if multiple parallel worker threads in a wds project start around the same time, one will trigger a build of the whole project and another will soon after trigger a build of just one file. Both builds are processed in parallel for speed, but if the timing is just right, both try to write to the same destination file around the same time. If one of the project threads is unlucky enough to read the file at around when it is being written, it can read an empty or half written file. Whoops!

`write-file-atomic` solves this problem by using a tmpfile and serializing writes made from within the same process.

I ran a stress test in the Gadget repo that boots many worker threads in parallel that almost always failed after one or two iterations before this change, and didn't fail after 10 mins of continuous booting locally!

COMPUTERS

[no-changelog-required]
