### PR TITLE
Support dots in directory names when running with esm: true

### DIFF
--- a/integration-test/reload/package.json
+++ b/integration-test/reload/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/integration-test/server/package.json
+++ b/integration-test/server/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wds",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "author": "Harry Brundage",
   "license": "MIT",
   "bin": {

--- a/spec/fixtures/esm/github.com/wds/simple.ts
+++ b/spec/fixtures/esm/github.com/wds/simple.ts
@@ -1,0 +1,1 @@
+console.log("success");

--- a/spec/fixtures/esm/package.json
+++ b/spec/fixtures/esm/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "wds-test-sources",
+  "version": "0.0.1",
+  "license": "MIT"
+}

--- a/spec/fixtures/esm/wds.js
+++ b/spec/fixtures/esm/wds.js
@@ -1,4 +1,5 @@
 module.exports = {
+  esm: true,
   swc: {
     jsc: {
       parser: {
@@ -7,11 +8,6 @@ module.exports = {
         dynamicImport: true,
       },
       target: "es2020",
-    },
-    module: {
-      type: "commonjs",
-      strictMode: true,
-      lazy: true,
     },
   },
 };


### PR DESCRIPTION
As the title suggests, before this PR if you had something like:

```
my-package/
--> package.json
--> src.abc/main.ts
```

The process of determining package type by ascending the parent directory chain would break, because eventually `!!extname("src.abc")` would be true and we'd run `fileURLToPath` on a non-URL because the first call with `main.ts` would have `isFilePath` true, and hence would have stripped the `file:///`.

We _could_ add it back, but as called out in the comment, checking `extname` is not a perfect solution. Instead, we allow passing in whether or not the given path is a file path or not, because as we ascend we know with certainty that we have directories. It's just the first call where we're uncertain, and will do a slightly more expensive `readdir` check. This should also be able to handle scenarios where you import a directory with an `index.ts`, for example.

There was also a secondary problem we had here: if we found a `package.json` file while ascending, but it had no `type` value, we'd keep ascending. This is actually wrong, as per the [node docs](https://nodejs.org/api/packages.html#type) that state:

> The nearest parent `package.json` is defined as the first package.json found when searching in the current folder, that folder's parent, and so on up until a node_modules folder or the volume root is reached.

> If the nearest parent `package.json` lacks a "type" field, or contains "type": "commonjs", .js files are treated as [CommonJS](https://nodejs.org/api/modules.html).