### PR TITLE
forward the kill signal received by the parent to the child process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wds",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "author": "Harry Brundage",
   "license": "MIT",
   "bin": {

--- a/src/Project.ts
+++ b/src/Project.ts
@@ -61,8 +61,8 @@ export class Project {
     this.supervisor.restart();
   }
 
-  async shutdown(code = 0) {
-    await this.supervisor.stop();
+  async shutdown(code: number, signal: NodeJS.Signals = "SIGTERM") {
+    await this.supervisor.stop(signal);
     for (const cleanup of this.cleanups) {
       cleanup();
     }

--- a/src/Supervisor.ts
+++ b/src/Supervisor.ts
@@ -14,11 +14,11 @@ export class Supervisor extends EventEmitter {
   }
 
   /**
-   * Stop the process with a graceful SIGTERM, then SIGKILL after a timeout
+   * Stop the process with a given signal, then SIGKILL after a timeout
    * Kills the whole process group so that any subprocesses of the process are also killed
    * See https://azimi.me/2014/12/31/kill-child_process-node-js.html for more information
    */
-  async stop() {
+  async stop(signal: NodeJS.Signals = "SIGTERM") {
     // if we never started the child process, we don't need to do anything
     if (!this.process || !this.process.pid) return;
 
@@ -27,7 +27,7 @@ export class Supervisor extends EventEmitter {
 
     const ref = this.process;
     const exit = once(ref, "exit");
-    this.kill("SIGTERM");
+    this.kill(signal);
 
     await Promise.race([exit, setTimeout(5000)]);
     if (!ref.killed) {
@@ -35,7 +35,7 @@ export class Supervisor extends EventEmitter {
     }
   }
 
-  kill(signal = "SIGKILL", pid = this.process?.pid) {
+  kill(signal: NodeJS.Signals = "SIGKILL", pid = this.process?.pid) {
     if (pid) {
       try {
         process.kill(-pid, signal);

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,11 +197,11 @@ export const wds = async (options: RunOptions) => {
 
   process.on("SIGINT", () => {
     log.debug(`process ${process.pid} got SIGINT`);
-    void project.shutdown(0);
+    void project.shutdown(0, "SIGINT");
   });
   process.on("SIGTERM", () => {
     log.debug(`process ${process.pid} got SIGTERM`);
-    void project.shutdown(0);
+    void project.shutdown(0, "SIGTERM");
   });
 
   project.supervisor.process.on("exit", (code, signal) => {


### PR DESCRIPTION
I noticed that when a subprocess reloader kills a process with `SIGINT` the actual sandbox process was getting `SIGTERM` which confused me until I realized that in dev the process that we are killing is wds, and its not forwarding the signal it receives on the the sandbox