### PR TITLE
Signal process group later

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wds",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "author": "Harry Brundage",
   "license": "MIT",
   "bin": {

--- a/spec/fixtures/src/grandchild.js
+++ b/spec/fixtures/src/grandchild.js
@@ -1,0 +1,21 @@
+console.log(`grandchild:ready:${process.pid}`);
+
+process.on("SIGINT", () => {
+  // swallow SIGINT and log
+  // let wds kill this process after a timeout
+  console.log("grandchild:sigint");
+});
+
+process.on("SIGQUIT", () => {
+  console.log("grandchild:sigquit");
+});
+
+process.on("SIGTERM", () => {
+  console.log("grandchild:sigterm");
+  process.exit(0);
+});
+
+// Keep alive
+setInterval(() => {}, 1e9);
+
+

--- a/spec/fixtures/src/signal-order.ts
+++ b/spec/fixtures/src/signal-order.ts
@@ -1,0 +1,38 @@
+import { spawn } from "child_process";
+import * as path from "path";
+
+// Spawn a long-lived grandchild that logs when it gets SIGTERM
+// Resolve from project root (wds runs child with cwd at project root)
+const grandchildPath = path.resolve(process.cwd(), "spec/fixtures/src/grandchild.js");
+const grandchild = spawn("node", [grandchildPath], {
+  stdio: ["ignore", "inherit", "inherit"],
+});
+
+console.log(`parent:ready:${process.pid}`);
+
+const exit = (signal: NodeJS.Signals) => {
+  console.log(`parent:exit-${signal}`);
+
+  grandchild.once("exit", () => {
+    console.log("parent:grandchild-exit");
+    process.exit(0);
+  });
+
+  setTimeout(() => {
+    console.log("parent:exit-timeout");
+    process.exit(0);
+  }, 2000);
+
+  grandchild.kill(signal);
+}
+
+process.on("SIGTERM", () => exit("SIGTERM"));
+process.on("SIGINT", () => exit("SIGINT"));
+process.on("SIGQUIT", () => {
+  console.log("parent:sigquit");
+});
+
+// Keep the process alive indefinitely until signaled
+setInterval(() => {}, 1e9);
+
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,10 @@ export const wds = async (options: RunOptions) => {
     log.debug(`process ${process.pid} got SIGTERM`);
     void project.shutdown(0, "SIGTERM");
   });
+  process.on("SIGQUIT", () => {
+    log.debug(`process ${process.pid} got SIGQUIT`);
+    void project.shutdown(0, "SIGQUIT");
+  });
 
   project.supervisor.process.on("exit", (code, signal) => {
     const logShutdown = (explanation: string) => {


### PR DESCRIPTION
While stress testing out vite middleware setup I kept running into a really strange error. I happen initially when the reloader proxy started shutting down a app sandbox process that was in processing a vite asset request. It turned out that the reloader proxy signal first goes through `wds` which which it receives a shutdown signal forwards it on to all processes in the process group of the child process. The bug occurred when this signal was sent while the esbuild child process that vite kicks off was in midflight. Since all processes in the group were signalled, esbuild would abruptly quit and failures would cascade from there.

This PR resolves this issue by moving wds shutdowns to staged approach

1. First just the child process is signalled, giving it the opportunity to shut down gracefully (and perhaps handle graceful shut downs of its child processes)
2. Once the child process exits we then issue the harsh kill 9 to all processes still running in the process group
3. The child process has 5s to gracefully shut down or else it will be kill 9-ed

I also had to make `shutdown` re-entrant since when the child process exits there is an independent listener for that that then calls shutdown again. This second entrance to `shutdown` was short circuiting the graceful shutdown and preventing the process group kill from occuring.