### PR TITLE
Allow compiling files in dot dirs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wds",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "author": "Harry Brundage",
   "license": "MIT",
   "bin": {

--- a/spec/SwcCompiler.test.ts
+++ b/spec/SwcCompiler.test.ts
@@ -25,6 +25,11 @@ test("compiles simple files", async () => {
   expect(content).toContain('console.log("success")');
 });
 
+test("compiles files in directories named .well-known", async () => {
+  const content = await compile("./.well-known/run.ts");
+  expect(content).toContain('console.log(_foo.foo)');
+});
+
 test("throws if the compilation fails", async () => {
   await expect(compile("./failing/failing.ts", "fixtures/failing")).rejects.toThrow(MissingDestinationError);
 });

--- a/spec/fixtures/src/.well-known/foo.ts
+++ b/spec/fixtures/src/.well-known/foo.ts
@@ -1,0 +1,1 @@
+export const foo = "foo";

--- a/spec/fixtures/src/.well-known/run.ts
+++ b/spec/fixtures/src/.well-known/run.ts
@@ -1,0 +1,3 @@
+import { foo } from "./foo";
+
+console.log(foo);

--- a/src/SwcCompiler.ts
+++ b/src/SwcCompiler.ts
@@ -198,6 +198,7 @@ export class SwcCompiler implements Compiler {
     let fileNames = await globby(config.includeGlob, {
       onlyFiles: true,
       cwd: root,
+      dot: true,
       absolute: true,
       ignore: ignores,
     });


### PR DESCRIPTION
Was finding that I couldn't use `api/routes/.well-known/GET-*.ts` type routes, dues to this annoying globby config