### PR TITLE
Fix ESM resolver fallback for pnpm symlinked dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wds",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "author": "Harry Brundage",
   "license": "MIT",
   "bin": {

--- a/src/hooks/child-process-esm-loader.ts
+++ b/src/hooks/child-process-esm-loader.ts
@@ -77,12 +77,7 @@ export const resolve: ResolveHook = async function resolve(specifier, context, n
   const resolved = await esmResolver.async(parentURL, specifier.startsWith("file:") ? fileURLToPath(specifier) : specifier);
   debugLog?.("oxc resolver result", { specifier, parentURL, resolved });
 
-  if (resolved.error) {
-    debugLog?.("esm custom resolver error", { specifier, parentURL, resolved, error: resolved.error });
-    throw new Error(`${resolved.error}: ${specifier} cannot be resolved in ${context.parentURL}`);
-  }
-
-  if (resolved.path) {
+  if (!resolved.error && resolved.path) {
     // we were able to resolve with our custom resolver
     const targetPath = resolved.path;
 
@@ -97,6 +92,8 @@ export const resolve: ResolveHook = async function resolve(specifier, context, n
         shortCircuit: true,
       };
     }
+  } else if (resolved.error) {
+    debugLog?.("oxc resolver failed, will try node fallback", { specifier, parentURL, error: resolved.error });
   }
 
   // we weren't able to resolve with our custom resolver, fallback to node's default resolver


### PR DESCRIPTION
## Fix ESM resolver fallback for pnpm symlinked dependencies

### Problem

When using `wds` with ESM mode (`esm: true`) in pnpm workspaces, module resolution fails for symlinked peer dependencies. For example, trying to import `graphql` from within `graphql-ws` results in:

```
Error: Cannot find module 'graphql': graphql cannot be resolved in file:///Users/.../node_modules/.pnpm/graphql-ws@5.16.2_graphql@16.8.1/node_modules/graphql-ws/lib/server.mjs
```

**Workaround:** Setting `esm: false` resolves the issue because the CJS hook uses Node's native `require()` resolution which handles pnpm symlinks correctly.

### Root Cause

The bug was in `child-process-esm-loader.ts` (lines 80-83). When oxc-resolver failed to resolve a module, it immediately threw an error instead of falling back to Node's built-in resolver:

```typescript
if (resolved.error) {
  debugLog?.("esm custom resolver error", { specifier, parentURL, resolved, error: resolved.error });
  throw new Error(`${resolved.error}: ${specifier} cannot be resolved in ${context.parentURL}`);
}
```

This prevented the existing fallback logic (lines 103-129) from ever running.

### Solution

Restructured the resolution logic to gracefully handle oxc-resolver failures:

1. ✅ Try oxc-resolver first (for TypeScript extension aliasing)
2. ✅ If oxc-resolver fails, log and continue to Node's native resolver (which handles pnpm symlinks)
3. ✅ If Node's resolver fails, try CommonJS require as last resort